### PR TITLE
Implement workaround

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import {
   NextPageSearchParamRecord,
   stringifySearchParams,
 } from "./url-helpers";
+import { SearchParamsFixer } from "./search-params-fixer";
 
 export default function Home({
   searchParams,
@@ -22,6 +23,7 @@ export default function Home({
       </div>
       <React.Suspense>
         <PageClient searchParamsOnServer={searchParams} />
+        <SearchParamsFixer searchParams={searchParams} />
       </React.Suspense>
     </>
   );

--- a/app/search-params-fixer.tsx
+++ b/app/search-params-fixer.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+// Source: https://github.com/kachkaev/next-js-search-params-mismatch-mwe/pull/1
+// Context: https://github.com/vercel/next.js/issues/64170
+
+import { useRouter, useSearchParams } from "next/navigation";
+import * as React from "react";
+import {
+  NextPageSearchParamRecord,
+  stringifySearchParams,
+} from "./url-helpers";
+
+export function SearchParamsFixer({
+  searchParams: searchParamsOnServer,
+}: {
+  searchParams: NextPageSearchParamRecord;
+}) {
+  const searchParamsOnClient = useSearchParams();
+  const router = useRouter();
+
+  React.useEffect(() => {
+    const stringifiedSearchParamsOnServer =
+      stringifySearchParams(searchParamsOnServer);
+    const stringifiedSearchParamsOnClient =
+      stringifySearchParams(searchParamsOnClient);
+
+    if (stringifiedSearchParamsOnServer === stringifiedSearchParamsOnClient) {
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      router.refresh();
+      // eslint-disable-next-line no-console
+      console.warn(
+        `SearchParamsFixer: refreshing page\n  [server] ${
+          stringifiedSearchParamsOnServer || "-"
+        }\n  [client] ${stringifiedSearchParamsOnClient || "-"}`
+      );
+    }, 100);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [router, searchParamsOnClient, searchParamsOnServer]);
+
+  return <></>;
+}


### PR DESCRIPTION
Context (issue details): https://github.com/vercel/next.js/issues/64170

https://github.com/kachkaev/next-js-search-params-mismatch-mwe/assets/608862/c27b9d41-3f89-46e7-a32d-8761d0a828f2

